### PR TITLE
Fix dynamic import in batch script

### DIFF
--- a/scripts/05_rodar_batch_perguntas.py
+++ b/scripts/05_rodar_batch_perguntas.py
@@ -1,6 +1,15 @@
 
 import csv
-from scripts.04_consultar_rag import gerar_resposta
+import importlib.util
+import os
+
+# Carrega dinamicamente o modulo `04_consultar_rag.py`,
+# evitando erro de sintaxe por causa do nome que comeca com digitos.
+_module_path = os.path.join(os.path.dirname(__file__), "04_consultar_rag.py")
+_spec = importlib.util.spec_from_file_location("consultar_rag", _module_path)
+_consultar_rag = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_consultar_rag)
+gerar_resposta = _consultar_rag.gerar_resposta
 
 def main():
     with open('data/perguntas.txt', 'r', encoding='utf-8') as f:


### PR DESCRIPTION
## Summary
- avoid syntax error when importing `04_consultar_rag.py`

## Testing
- `python -m py_compile scripts/05_rodar_batch_perguntas.py`
- `python -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68421f7648b4832797181fe7a78f9267